### PR TITLE
fix(extend+assign+deassign)!: fix overall buggy timer behaviour

### DIFF
--- a/handlers/WebhookHandlers.go
+++ b/handlers/WebhookHandlers.go
@@ -225,32 +225,14 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Str("contributor", contributorHandle).
 			Msg("Failed to send /register request to TimerDaemon")
+		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Timer service is unavailable. Please try again later.")
 		return
 	}
 
 	if response == nil {
 		globals.AppState.ZeroLogger.Error().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Msg("No response from the timer service")
-
-		response := "Failed to assign issue. Failed to allot a timer for the contributor"
-		comment := github.IssueComment{Body: &response}
-
-		_, _, err := globals.AppState.RuntimeClient.Issues.CreateComment(context.TODO(), parsedHook.Repository.Owner.Login, parsedHook.Repository.Name, int(parsedHook.Issue.Number), &comment)
-
-		if err != nil {
-			globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).
-				Str("repoName", parsedHook.Repository.FullName).
-				Int64("issueNum", parsedHook.Issue.Number).
-				Str("issueTitle", parsedHook.Issue.Title).
-				Msg("Could not Comment on Issue")
-		} else {
-			globals.AppState.ZeroLogger.Info().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).
-				Str("repoName", parsedHook.Repository.FullName).
-				Int64("issueNum", parsedHook.Issue.Number).
-				Str("issueTitle", parsedHook.Issue.Title).
-				Msg("Successfully Commented on Issue")
-		}
-
+		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Failed to allot a timer for the contributor")
 		return
 	}
 
@@ -259,6 +241,8 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 			Str("contributor", contributorHandle).
 			Int("statusCode", response.StatusCode).
 			Msg("POST /register recieved")
+		errorMsg := fmt.Sprintf("Failed to assign issue. Timer service returned error (status: %d). Please try again later.", response.StatusCode)
+		rollbackAssignmentHandler(parsedHook, contributorHandle, errorMsg)
 	} else {
 		globals.AppState.ZeroLogger.Info().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).
 			Str("contributor", contributorHandle).
@@ -628,6 +612,61 @@ func extendIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 				Str("issueTitle", parsedHook.Issue.Title).
 				Msg("Successfully Commented on Issue")
 		}
+	}
+}
+
+func rollbackAssignmentHandler(parsedHook *ghwebhooks.IssueCommentPayload, contributorHandle string, errorMessage string) {
+	globals.AppState.ZeroLogger.Error().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
+		Str("contributor", contributorHandle).
+		Msg("Rolling back assignment due to timer failure")
+
+	// Rollback DB assignment
+	dbSuccess, err := globals.AppState.DBManager.DeassignIssue(parsedHook.Issue.HTMLURL)
+	if err != nil {
+		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
+			Str("contributor", contributorHandle).
+			Msg("Failed to rollback DB assignment")
+	} else if !dbSuccess {
+		globals.AppState.ZeroLogger.Error().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
+			Str("contributor", contributorHandle).
+			Msg("Failed to rollback DB assignment, DB error")
+	}
+
+	// Rollback GitHub assignment
+	_, _, err = globals.AppState.RuntimeClient.Issues.RemoveAssignees(
+		context.TODO(),
+		parsedHook.Repository.Owner.Login,
+		parsedHook.Repository.Name,
+		int(parsedHook.Issue.Number),
+		[]string{contributorHandle},
+	)
+	if err != nil {
+		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK").Str("GH_API")).
+			Str("contributor", contributorHandle).
+			Msg("Failed to rollback GitHub assignment")
+	}
+
+	// Notify user of failure
+	comment := github.IssueComment{Body: &errorMessage}
+	_, _, err = globals.AppState.RuntimeClient.Issues.CreateComment(
+		context.TODO(),
+		parsedHook.Repository.Owner.Login,
+		parsedHook.Repository.Name,
+		int(parsedHook.Issue.Number),
+		&comment,
+	)
+	if err != nil {
+		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
+			Str("repoName", parsedHook.Repository.FullName).
+			Int64("issueNum", parsedHook.Issue.Number).
+			Str("issueTitle", parsedHook.Issue.Title).
+			Msg("Could not comment on issue about assignment failure")
+	} else {
+		globals.AppState.ZeroLogger.Info().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
+			Str("repoName", parsedHook.Repository.FullName).
+			Int64("issueNum", parsedHook.Issue.Number).
+			Str("issueTitle", parsedHook.Issue.Title).
+			Msg("Successfully commented on issue about assignment failure")
 	}
 }
 

--- a/handlers/WebhookHandlers.go
+++ b/handlers/WebhookHandlers.go
@@ -348,7 +348,7 @@ func deassignIssue(parsedHook *ghwebhooks.IssueCommentPayload) {
 			Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("DEASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Msg("No response from the timer service")
 
-		response := "Failed to deassign issue. Failed to allot a timer for the contributor. Contact @bwaklog @anirudhsudhir"
+		response := "Deassigned issue. Failed to delete timer for the contributor. Contact @bwaklog @anirudhsudhir"
 		comment := github.IssueComment{Body: &response}
 
 		_, _, err := globals.AppState.RuntimeClient.Issues.CreateComment(context.TODO(), parsedHook.Repository.Owner.Login, parsedHook.Repository.Name, int(parsedHook.Issue.Number), &comment)
@@ -594,7 +594,7 @@ func extendIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 			Int("statusCode", response.StatusCode).
 			Str("message", extendEventResponse.Message).
 			Msg("POST /extend recieved")
-		if response.StatusCode == http.StatusExpectationFailed {
+		if response.StatusCode == http.StatusFailedDependency {
 			globals.AppState.ZeroLogger.Error().
 				Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("EXTEND_ISSUE")).
 				Str("assignee", parsedHook.Issue.Assignee.Login).

--- a/handlers/WebhookHandlers.go
+++ b/handlers/WebhookHandlers.go
@@ -225,14 +225,14 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Str("contributor", contributorHandle).
 			Msg("Failed to send /register request to TimerDaemon")
-		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Timer service is unavailable. Please try again later.")
+		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Failed to send timer for the contributor. Contact @bwaklog @anirudhsudhir")
 		return
 	}
 
 	if response == nil {
 		globals.AppState.ZeroLogger.Error().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Msg("No response from the timer service")
-		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Failed to allot a timer for the contributor")
+		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Failed to allot a timer for the contributor. Contact @bwaklog @anirudhsudhir")
 		return
 	}
 
@@ -241,7 +241,7 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 			Str("contributor", contributorHandle).
 			Int("statusCode", response.StatusCode).
 			Msg("POST /register recieved")
-		errorMsg := fmt.Sprintf("Failed to assign issue. Timer service returned error (status: %d). Please try again later.", response.StatusCode)
+		errorMsg := fmt.Sprintf("Failed to assign issue. Failed to allot a timer for the contributor (%d). Contact @bwaklog @anirudhsudhir", response.StatusCode)
 		rollbackAssignmentHandler(parsedHook, contributorHandle, errorMsg)
 	} else {
 		globals.AppState.ZeroLogger.Info().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).

--- a/handlers/WebhookHandlers.go
+++ b/handlers/WebhookHandlers.go
@@ -594,6 +594,14 @@ func extendIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 			Int("statusCode", response.StatusCode).
 			Str("message", extendEventResponse.Message).
 			Msg("POST /extend recieved")
+		if response.StatusCode == http.StatusExpectationFailed {
+			globals.AppState.ZeroLogger.Error().
+				Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("EXTEND_ISSUE")).
+				Str("assignee", parsedHook.Issue.Assignee.Login).
+				Msg("Timer expired for assignee, deassigning and assigning")
+			deassignIssue(parsedHook)
+			assignIssue(extendToAssign(commentCommand, parsedHook.Issue.Assignee.Login), parsedHook)
+		}
 	} else {
 		globals.AppState.ZeroLogger.Info().
 			Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("EXTEND_ISSUE")).

--- a/handlers/WebhookHandlers.go
+++ b/handlers/WebhookHandlers.go
@@ -464,7 +464,7 @@ func withdrawIssue(parsedHook *ghwebhooks.IssueCommentPayload) {
 			Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("WITHDRAW_ISSUE").Str("TIMER_DAEMON")).
 			Msg("No response from the timer service")
 
-		response := "Failed to withdraw issue. Failed to allot a timer for the contributor. Contact @bwaklog @anirudhsudhir"
+		response := "Issue withdrawn. Failed to allot a timer for the contributor. Contact @bwaklog @anirudhsudhir"
 		comment := github.IssueComment{Body: &response}
 
 		_, _, err := globals.AppState.RuntimeClient.Issues.CreateComment(context.TODO(), parsedHook.Repository.Owner.Login, parsedHook.Repository.Name, int(parsedHook.Issue.Number), &comment)

--- a/handlers/WebhookHelpers.go
+++ b/handlers/WebhookHelpers.go
@@ -116,6 +116,17 @@ func parseExtend(comment string) (int, bool) {
 
 }
 
+func extendToAssign(comment string, assignee string) string {
+	comment = strings.TrimLeft(comment, " ")
+	matches := extendRegex.FindStringSubmatch(comment)
+	if len(matches) > 1 && matches[1] != "" {
+		timeStr := matches[1]
+		return "!assign @" + assignee + " " + timeStr
+	} else {
+		return "!assign @" + assignee + " 30"
+	}
+}
+
 // Function to check if a URL is a Pull Request URL
 func isPullRequest(url string) bool {
 	// Github Pull Request URLs are of the form


### PR DESCRIPTION
BREAKING CHANGES:
 - assign now has a hard dependency on /register in saturn
 - extend now deassigns and reassigns when timer has expired (most likely scenario to be honest, but always be prepared)
 
Other changes:
 - fix the comments made to actual reflect that deassign and withdraw happen regardless of timer being alive.

TODO:
 - move maintainer list into app state so we can actually have it be changed relatively quickly, other option of reading from db every time is going to be a pain
 - change the debug comments to be more reflective of how they need to be in production