### PR TITLE
revert(assign): make timer a soft dependency again

### DIFF
--- a/handlers/WebhookHandlers.go
+++ b/handlers/WebhookHandlers.go
@@ -189,7 +189,7 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 	if err != nil {
 		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Str("sender", contributorHandle).
-			Msg("Failed to assign issue. Failed to marshal bytes for request to TimerDaemon")
+			Msg("Failed to assign timer. Failed to marshal bytes for request to TimerDaemon")
 		return
 	}
 
@@ -207,7 +207,7 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 	if err != nil {
 		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).
 			Str("sender", contributorHandle).
-			Msg("Failed to assign issue. Failed to marshal bytes for request to TimerDaemon")
+			Msg("Failed to assign timer. Failed to marshal bytes for request to TimerDaemon")
 		return
 	}
 
@@ -225,14 +225,32 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Str("contributor", contributorHandle).
 			Msg("Failed to send /register request to TimerDaemon")
-		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Failed to send timer for the contributor. Contact @bwaklog @anirudhsudhir")
 		return
 	}
 
 	if response == nil {
 		globals.AppState.ZeroLogger.Error().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("TIMER_DAEMON")).
 			Msg("No response from the timer service")
-		rollbackAssignmentHandler(parsedHook, contributorHandle, "Failed to assign issue. Failed to allot a timer for the contributor. Contact @bwaklog @anirudhsudhir")
+
+		response := "Assigned issue. Failed to allot a timer for the contributor @" + parsedHook.Sender.Login
+		comment := github.IssueComment{Body: &response}
+
+		_, _, err := globals.AppState.RuntimeClient.Issues.CreateComment(context.TODO(), parsedHook.Repository.Owner.Login, parsedHook.Repository.Name, int(parsedHook.Issue.Number), &comment)
+
+		if err != nil {
+			globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).
+				Str("repoName", parsedHook.Repository.FullName).
+				Int64("issueNum", parsedHook.Issue.Number).
+				Str("issueTitle", parsedHook.Issue.Title).
+				Msg("Could not Comment on Issue")
+		} else {
+			globals.AppState.ZeroLogger.Info().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).
+				Str("repoName", parsedHook.Repository.FullName).
+				Int64("issueNum", parsedHook.Issue.Number).
+				Str("issueTitle", parsedHook.Issue.Title).
+				Msg("Successfully Commented on Issue")
+		}
+
 		return
 	}
 
@@ -241,8 +259,6 @@ func assignIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 			Str("contributor", contributorHandle).
 			Int("statusCode", response.StatusCode).
 			Msg("POST /register recieved")
-		errorMsg := fmt.Sprintf("Failed to assign issue. Failed to allot a timer for the contributor (%d). Contact @bwaklog @anirudhsudhir", response.StatusCode)
-		rollbackAssignmentHandler(parsedHook, contributorHandle, errorMsg)
 	} else {
 		globals.AppState.ZeroLogger.Info().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE")).
 			Str("contributor", contributorHandle).
@@ -310,7 +326,7 @@ func deassignIssue(parsedHook *ghwebhooks.IssueCommentPayload) {
 		globals.AppState.ZeroLogger.Error().Err(err).
 			Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("DEASSIGN_ISSUE")).
 			Str("assignee", parsedHook.Issue.Assignee.Login).
-			Msg("Failed to deassign issue. Failed to marshal bytes for request to TimerDaemon")
+			Msg("Failed to deassign timer. Failed to marshal bytes for request to TimerDaemon")
 		return
 	}
 
@@ -612,61 +628,6 @@ func extendIssue(commentCommand string, parsedHook *ghwebhooks.IssueCommentPaylo
 				Str("issueTitle", parsedHook.Issue.Title).
 				Msg("Successfully Commented on Issue")
 		}
-	}
-}
-
-func rollbackAssignmentHandler(parsedHook *ghwebhooks.IssueCommentPayload, contributorHandle string, errorMessage string) {
-	globals.AppState.ZeroLogger.Error().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
-		Str("contributor", contributorHandle).
-		Msg("Rolling back assignment due to timer failure")
-
-	// Rollback DB assignment
-	dbSuccess, err := globals.AppState.DBManager.DeassignIssue(parsedHook.Issue.HTMLURL)
-	if err != nil {
-		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
-			Str("contributor", contributorHandle).
-			Msg("Failed to rollback DB assignment")
-	} else if !dbSuccess {
-		globals.AppState.ZeroLogger.Error().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
-			Str("contributor", contributorHandle).
-			Msg("Failed to rollback DB assignment, DB error")
-	}
-
-	// Rollback GitHub assignment
-	_, _, err = globals.AppState.RuntimeClient.Issues.RemoveAssignees(
-		context.TODO(),
-		parsedHook.Repository.Owner.Login,
-		parsedHook.Repository.Name,
-		int(parsedHook.Issue.Number),
-		[]string{contributorHandle},
-	)
-	if err != nil {
-		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK").Str("GH_API")).
-			Str("contributor", contributorHandle).
-			Msg("Failed to rollback GitHub assignment")
-	}
-
-	// Notify user of failure
-	comment := github.IssueComment{Body: &errorMessage}
-	_, _, err = globals.AppState.RuntimeClient.Issues.CreateComment(
-		context.TODO(),
-		parsedHook.Repository.Owner.Login,
-		parsedHook.Repository.Name,
-		int(parsedHook.Issue.Number),
-		&comment,
-	)
-	if err != nil {
-		globals.AppState.ZeroLogger.Error().Err(err).Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
-			Str("repoName", parsedHook.Repository.FullName).
-			Int64("issueNum", parsedHook.Issue.Number).
-			Str("issueTitle", parsedHook.Issue.Title).
-			Msg("Could not comment on issue about assignment failure")
-	} else {
-		globals.AppState.ZeroLogger.Info().Array("scope", zerolog.Arr().Str("ISSUE_COMMENT_HANDLER").Str("ASSIGN_ISSUE").Str("ROLLBACK")).
-			Str("repoName", parsedHook.Repository.FullName).
-			Int64("issueNum", parsedHook.Issue.Number).
-			Str("issueTitle", parsedHook.Issue.Title).
-			Msg("Successfully commented on issue about assignment failure")
 	}
 }
 


### PR DESCRIPTION
Undo the disaster that was waiting to happen, having the rollback not be atomic is kinda _hehehe_.

Changes:
- Reverted the timer hard dependency to no longer be a hard dependency.
- Added notification to a maintainer when assign doesn't allot a timer.